### PR TITLE
Define dtype of box numpy array as float

### DIFF
--- a/run.py
+++ b/run.py
@@ -52,7 +52,7 @@ def main(name, file):
         label_name = image_name.replace(extension, 'txt')
 
         # The COCO bounding box format is [top left x, top left y, width, height]
-        box = np.array(x['bbox'])
+        box = np.array(x['bbox'],dtype=np.float64)
         box[:2] += box[2:] / 2  # xy top-left corner to center
         box[[0, 2]] /= width[i]  # normalize x
         box[[1, 3]] /= height[i]  # normalize y


### PR DESCRIPTION
Originally the box numpy array was created as a numpy array of dtype **int64**. This causes errors while doing the subsequent operations as those can only be done on float arrays. Minor change to define the box numpy array with dtype **float64** from the start fixes this issue.