### PR TITLE
fix segments issue

### DIFF
--- a/general_json2yolo.py
+++ b/general_json2yolo.py
@@ -280,8 +280,13 @@ def convert_coco_json(json_dir='../coco/annotations/', use_segments=False, cls91
 
             # Segments
             if use_segments:
-                segments = [j for i in x['segmentation'] for j in i]  # all segments concatenated
-                s = (np.array(segments).reshape(-1, 2) / np.array([w, h])).reshape(-1).tolist()
+                if len(x['segmentation']) > 1:
+                    s = merge_multi_segment(x['segmentation'])
+                    s = (np.concatenate(s, axis=0) / np.array([w, h])).reshape(-1).tolist()
+
+                else:
+                    segments = [j for i in x['segmentation'] for j in i]  # all segments concatenated
+                    s = (np.array(segments).reshape(-1, 2) / np.array([w, h])).reshape(-1).tolist()
 
             # Write
             if box[2] > 0 and box[3] > 0:  # if w > 0 and h > 0
@@ -289,6 +294,72 @@ def convert_coco_json(json_dir='../coco/annotations/', use_segments=False, cls91
                 line = cls, *(s if use_segments else box)  # cls, box or segments
                 with open((fn / f).with_suffix('.txt'), 'a') as file:
                     file.write(('%g ' * len(line)).rstrip() % line + '\n')
+
+def min_index(arr1, arr2):
+    """Find a pair of indexes with the shortest distance. 
+    Args:
+        arr1: (N, 2).
+        arr2: (M, 2).
+    Return:
+        a pair of indexes(tuple).
+    """
+    # (N, M)
+    dis = ((arr1[:, None, :] - arr2[None, :, :]) ** 2).sum(-1)
+    index = np.unravel_index(np.argmin(dis, axis=None), dis.shape)
+    return index
+
+
+def merge_multi_segment(segments):
+    """Merge multi segments to one list.
+    Find the coordinates with min distance between each segment,
+    then connect these coordinates with one thin line to merge all 
+    segments into one.
+
+    Args:
+        segments(List(List)): original segmentations in coco's json file.
+            like [segmentation1, segmentation2,...], 
+            each segmentation is a list of coordinates.
+    """
+    s = []
+    segments = [np.array(i).reshape(-1, 2) for i in segments]
+    idx_list = [[] for _ in range(len(segments))]
+
+    # record the indexes with min distance between each segment
+    for i in range(1, len(segments)):
+        idx1, idx2 = min_index(segments[i - 1], segments[i])
+        idx_list[i - 1].append(idx1)
+        idx_list[i].append(idx2)
+
+    # use two round to connect all the segments
+    for k in range(2):
+        # forward connection
+        if k == 0:
+            for i, idx in enumerate(idx_list):
+                # middle segments have two indexes
+                # reverse the index of middle segments
+                if len(idx) == 2 and idx[0] > idx[1]:
+                    idx = idx[::-1]       
+                    segments[i] = segments[i][::-1, :]
+
+                segments[i] = np.roll(segments[i], -idx[0], axis=0)
+                segments[i] = np.concatenate([segments[i], segments[i][0:1]])
+                # deal with the first segment and the last one
+                if i == 0 or i == (len(idx_list) - 1):
+                    s.append(segments[i])
+                # deal with the middle ones
+                else:
+                    idx = [0, idx[1] - idx[0]]
+                    s.append(segments[i][idx[0]:idx[1] + 1])
+
+        # backward connection
+        else:
+            for i in range(len(idx_list) - 1, -1, -1):
+                if i != 0 and i != (len(idx_list) - 1):
+                    idx = idx_list[i]
+                    nidx = abs(idx[1] - idx[0])
+                    s.append(segments[i][nidx:])
+    return s
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some objects in coco have multiple parts of segmentation, like:
"segmentation": [[part1], [part2],...].
The way of conversion from coco to yolo simply treat multiple segments as one, 
[https://github.com/ultralytics/JSON2YOLO/blob/4fd2104a7b9e5557e001fd07526e7f71236a4d93/general_json2yolo.py#L283](https://github.com/ultralytics/JSON2YOLO/blob/4fd2104a7b9e5557e001fd07526e7f71236a4d93/general_json2yolo.py#L283)
which the txt labels can be visualized like this:
![all_wrong](https://user-images.githubusercontent.com/61612323/185864069-f61bbbcd-0daf-4761-9b3e-2699175fc207.jpg)
 so the labels can be really wrong(check the black box).

The best way to deal with multiple parts of segmentation is to handle these parts separately. If so, we may need to make more changes to the instance segmentation dataloader. So I connect these parts with thin lines, like below:
![all_right](https://user-images.githubusercontent.com/61612323/185865993-8b5fec6c-21db-47ab-9f49-9be31ce7cb4a.jpg)

The labels seems perfect except some of them have one thin line, and the dataloader of instance segmentation does not need any modification.

