### PR TITLE
add delete_dirs function

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -69,11 +69,25 @@ def split_indices(x, train=0.9, test=0.1, validate=0.0, shuffle=True):  # split 
     return v[:i], v[i:j], v[j:k]  # return indices
 
 
+def delete_dirs(str_dir):
+    # Delete files in folders
+    ls = os.listdir(str_dir)
+    for name in ls:
+        c_path = os.path.join(str_dir, name)
+        if os.path.isdir(c_path):
+            delete_dirs(c_path)
+        else:
+            if c_path.endswith(".jpg") or c_path.endswith(".bmp") or c_path.endswith(".jpeg") or\
+               c_path.endswith(".png") or c_path.endswith(".tif") or c_path.endswith(".tiff") or\
+               c_path.endswith(".dng") or c_path.endswith(".txt"):
+                os.remove(c_path)
+
+
 def make_dirs(dir='new_dir/'):
     # Create folders
     dir = Path(dir)
     if dir.exists():
-        shutil.rmtree(dir)  # delete dir
+        delete_dirs(dir)  # delete dir
     for p in dir, dir / 'labels', dir / 'images':
         p.mkdir(parents=True, exist_ok=True)  # make dir
     return dir


### PR DESCRIPTION
When I used this tool to convert, I made a mistake in the path and the code and other files under the path was deleted, so I think specified that the file to be deleted was a newly generated file.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 📊 Key Changes
- Added a new `delete_dirs` function to `utils.py`.
- Modified the `make_dirs` function to use the new `delete_dirs` instead of `shutil.rmtree` for directory deletion.

### 🎯 Purpose & Impact
- The `delete_dirs` function is designed to selectively delete files with specific image extensions (like `.jpg`, `.png`, etc.) and `.txt` files within a directory.
- This addition is safer, as it does not remove directories themselves but rather cleanses them of certain file types, reducing the risk of inadvertently deleting important data or directories.
- It also could be seen as a more organized way of handling directory content management, focusing on specific file types related to image processing and machine learning tasks that Ultralytics software commonly deals with.

### 🌟 Summary
🗑️ "Introducing a targeted directory cleanup function to safely remove image and text files without erasing entire folders!"