### PR TITLE
Standardize license headers in Python files

### DIFF
--- a/general_json2yolo.py
+++ b/general_json2yolo.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 import cv2
 import pandas as pd
 from PIL import Image
+
 from utils import *
 
 

--- a/general_json2yolo.py
+++ b/general_json2yolo.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import contextlib
 import json
 from collections import defaultdict
@@ -5,7 +7,6 @@ from collections import defaultdict
 import cv2
 import pandas as pd
 from PIL import Image
-
 from utils import *
 
 

--- a/labelbox_json2yolo.py
+++ b/labelbox_json2yolo.py
@@ -8,6 +8,7 @@ import requests
 import yaml
 from PIL import Image
 from tqdm import tqdm
+
 from utils import make_dirs
 
 

--- a/labelbox_json2yolo.py
+++ b/labelbox_json2yolo.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import json
 import os
 from pathlib import Path
@@ -6,7 +8,6 @@ import requests
 import yaml
 from PIL import Image
 from tqdm import tqdm
-
 from utils import make_dirs
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import glob
 import os
 import shutil


### PR DESCRIPTION
This PR updates all Python file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all Python files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added licensing headers to files in the `JSON2YOLO` project for improved compliance and clarity. 📝✨  

### 📊 Key Changes  
- Added `Ultralytics AGPL-3.0 License` headers to the following files:  
  - `general_json2yolo.py`  
  - `labelbox_json2yolo.py`  
  - `utils.py`  
- Removed unnecessary blank lines for minor code formatting improvements.  

### 🎯 Purpose & Impact  
- **Purpose**: Ensures all files clearly state their licensing terms, improving transparency and legal compliance.  
- **Impact**: Helps users and contributors understand and respect the licensing requirements while promoting responsible usage. 🛡️