### PR TITLE
Add redirect notice to `ultralytics` repo for new updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ convert_coco(
 
 This method processes your JSON file, converts annotations (bounding boxes and keypoints), and saves the labels in YOLO format (`.txt` files) within the specified directory. For more details, refer to our [dataset format documentation](https://docs.ultralytics.com/datasets/).
 
-
 ## 📚 Citation
 
 If you find our tool useful for your research or development, please consider citing it:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This conversion process is essential for [machine learning](https://www.ultralyt
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
-> **📢 Important Update**: The JSON2YOLO project is now integrated into the main Ultralytics package. The standalone scripts in this repository are no longer being actively updated. For the latest functionality, please use the new `convert_coco()` method described in our updated [data converter documentation](https://docs.ultralytics.com/reference/data/converter/).
+> **📢 Important Update**: The JSON2YOLO project is now integrated into the main Ultralytics package at https://github.com/ultralytics/ultralytics. The standalone scripts in this repository are no longer being actively updated. For the latest functionality, please use the new `convert_coco()` method described in our updated [data converter documentation](https://docs.ultralytics.com/reference/data/converter/).
 
 ## ⚙️ Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This conversion process is essential for [machine learning](https://www.ultralyt
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
 > **⚠️ Disclaimer**: This project has been moved and embedded in the ultralytics main package. The standalone converter scripts in this repository are deprecated. The documentation of the new package can be seen at the documentation of the new
-`convert_coco()` in the [Ultralytics data converter reference documentation](https://docs.ultralytics.com/reference/data/converter/). 
+> `convert_coco()` in the [Ultralytics data converter reference documentation](https://docs.ultralytics.com/reference/data/converter/).
 
 ## ⚙️ Requirements
 
@@ -30,7 +30,7 @@ This package has become part of the ultralytics python package. Therefore the co
 from ultralytics.data.converter import convert_coco
 
 convert_coco(
-    labels_dir="<path/to/labels.json>", 
+    labels_dir="<path/to/labels.json>",
     save_dir="<path/to/output_dir>",
     use_keypoints=True,
 )

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ from ultralytics.data.converter import convert_coco
 
 convert_coco(
     labels_dir="<path/to/labels.json>", 
-    save_dir="<path/to/output.txt>",
+    save_dir="<path/to/output_dir>",
     use_keypoints=True,
 )
 ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ This conversion process is essential for [machine learning](https://www.ultralyt
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
-> **⚠️ Disclaimer**: This project has been moved and embedded in the ultralytics main package. The standalone converter scripts in this repository are deprecated. The documentation of the new package can be seen at the documentation of the new
-> `convert_coco()` in the [Ultralytics data converter reference documentation](https://docs.ultralytics.com/reference/data/converter/).
+> **📢 Important Update**: The JSON2YOLO project is now integrated into the main Ultralytics package. The standalone scripts in this repository are no longer being actively updated. For the latest functionality, please use the new `convert_coco()` method described in our updated [data converter documentation](https://docs.ultralytics.com/reference/data/converter/).
 
 ## ⚙️ Requirements
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This conversion process is essential for [machine learning](https://www.ultralyt
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
+> **⚠️ Disclaimer**: This project has been moved and embedded in the ultralytics main package. The standalone converter scripts in this repository are deprecated. The documentation of the new package can be seen at the documentation of the new
+`convert_coco()` in the [Ultralytics data converter reference documentation](https://docs.ultralytics.com/reference/data/converter/). 
+
 ## ⚙️ Requirements
 
 To get started with JSON2YOLO, you'll need a [Python](https://www.python.org/) environment running version 3.8 or later. Additionally, you'll need to install all the necessary dependencies listed in the `requirements.txt` file. You can install these dependencies using the following [pip](https://pip.pypa.io/en/stable/) command in your terminal:
@@ -21,17 +24,19 @@ pip install -r requirements.txt # Installs all the required packages
 
 ## 💡 Usage
 
-To convert your COCO JSON dataset to YOLO format, run the `convert.py` script from your terminal. You need to specify the path to the directory containing your COCO JSON annotation files and the directory where you want to save the resulting YOLO label files.
+This package has become part of the ultralytics python package. Therefore the conversion can be done with the `coco_convert` method. An example of keypoint annotated labels looks like this:
 
-```bash
-# Example usage: Convert COCO annotations to YOLO format
-python convert.py --json_dir path/to/coco/annotations --save_dir path/to/yolo/labels
+```python
+from ultralytics.data.converter import convert_coco
+
+convert_coco(
+    labels_dir="<path/to/labels.json>", 
+    save_dir="<path/to/output.txt>",
+    use_keypoints=True,
+)
 ```
 
-- `--json_dir`: Path to the directory containing COCO JSON annotation files (e.g., `instances_train2017.json`).
-- `--save_dir`: Path to the directory where the converted YOLO label files (`.txt`) will be saved.
-
-This script will process the JSON files, extract bounding box information, and convert it into the YOLO format, saving one `.txt` file per image in the specified save directory. For more details on [dataset formats](https://docs.ultralytics.com/datasets/), refer to our documentation.
+This method will process the JSON files, extract bounding box information, and convert it into the YOLO format, saving one `.txt` file per image in the specified save directory. For more details on [dataset formats](https://docs.ultralytics.com/datasets/), refer to our documentation.
 
 ## 📚 Citation
 

--- a/README.md
+++ b/README.md
@@ -23,19 +23,26 @@ pip install -r requirements.txt # Installs all the required packages
 
 ## 💡 Usage
 
-This package has become part of the ultralytics python package. Therefore the conversion can be done with the `coco_convert` method. An example of keypoint annotated labels looks like this:
+JSON2YOLO functionality is now part of the main `ultralytics` Python package. To use the converter, first install the package:
+
+```bash
+pip install ultralytics
+```
+
+You can then easily convert COCO JSON datasets to YOLO format using the `convert_coco` method. Here's an example using keypoint annotations:
 
 ```python
 from ultralytics.data.converter import convert_coco
 
 convert_coco(
-    labels_dir="<path/to/labels.json>",
-    save_dir="<path/to/output_dir>",
+    labels_dir="path/to/labels.json",
+    save_dir="path/to/output_dir",
     use_keypoints=True,
 )
 ```
 
-This method will process the JSON files, extract bounding box information, and convert it into the YOLO format, saving one `.txt` file per image in the specified save directory. For more details on [dataset formats](https://docs.ultralytics.com/datasets/), refer to our documentation.
+This method processes your JSON file, converts annotations (bounding boxes and keypoints), and saves the labels in YOLO format (`.txt` files) within the specified directory. For more details, refer to our [dataset format documentation](https://docs.ultralytics.com/datasets/).
+
 
 ## 📚 Citation
 


### PR DESCRIPTION
…



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
JSON2YOLO is now integrated into the main Ultralytics package, with updated instructions for using the new built-in data conversion method. 🚀

### 📊 Key Changes
- Added a prominent notice that JSON2YOLO is now part of the main Ultralytics package.
- Updated usage instructions to recommend the new `convert_coco()` method from Ultralytics, replacing the old standalone script.
- Provided a clear Python code example for converting COCO JSON datasets (including keypoints) to YOLO format using the Ultralytics package.
- Updated documentation links to guide users to the latest resources.

### 🎯 Purpose & Impact
- Ensures users access the latest, actively maintained data conversion tools directly from the Ultralytics package.
- Simplifies the conversion process with a modern, Pythonic interface.
- Reduces confusion by clearly directing users away from outdated standalone scripts.
- Helps users stay up-to-date with improvements and support in the main Ultralytics ecosystem. 🌟