### PR TITLE
Improve standalone converters and add CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt pytest
+        run: uv pip install --system -r requirements.txt pytest
 
       - name: Compile Python files
-        run: python -m compileall -q .
+        run: uv run python -m compileall -q .
 
       - name: Run tests
-        run: pytest -q
+        run: uv run pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv pip install --system -r requirements.txt pytest
+        run: uv pip install --system -r requirements.txt pytest ultralytics
 
       - name: Compile Python files
         run: uv run python -m compileall -q .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@
 name: CI
 
 on:
+  schedule:
+    - cron: "0 8 * * *"
   pull_request:
     branches: [main]
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Compile Python files
+        run: python -m compileall -q .
+
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -23,30 +23,54 @@ pip install -r requirements.txt # Installs all the required packages
 
 ## 💡 Usage
 
-JSON2YOLO functionality is now part of the main `ultralytics` Python package. To use the converter, first install the package:
+JSON2YOLO functionality is now part of the main `ultralytics` Python package. For new projects, install `ultralytics` and use the maintained converter:
 
 ```bash
 pip install ultralytics
 ```
 
-You can then easily convert COCO JSON datasets to YOLO format using the `convert_coco` method. Here's an example using keypoint annotations:
-
 ```python
 from ultralytics.data.converter import convert_coco
 
 convert_coco(
-    labels_dir="path/to/labels.json",
+    labels_dir="path/to/annotations",
     save_dir="path/to/output_dir",
+    use_segments=False,
     use_keypoints=True,
 )
 ```
 
-This method processes your JSON file, converts annotations (bounding boxes and keypoints), and saves the labels in YOLO format (`.txt` files) within the specified directory. For more details, refer to our [dataset format documentation](https://docs.ultralytics.com/datasets/).
+This method processes COCO detection, segmentation, and keypoint annotations and saves YOLO labels in the specified directory. For more details, refer to the [dataset format documentation](https://docs.ultralytics.com/datasets/).
 
 Legacy standalone script usage is still available for existing workflows:
 
 ```bash
-python general_json2yolo.py --source COCO --json-dir path/to/annotations --use-segments
+python general_json2yolo.py --source COCO --json-dir path/to/annotations --save-dir yolo_out
+python general_json2yolo.py --source COCO --json-dir path/to/annotations --use-segments --save-dir yolo_seg
+python general_json2yolo.py --source COCO --json-dir path/to/annotations --use-keypoints --save-dir yolo_pose
+```
+
+The standalone converter also supports LabelMe polygon, rectangle, circle, linestrip, and mask annotations:
+
+```bash
+python general_json2yolo.py --source LabelMe --json-dir path/to/labelme_jsons --use-segments --save-dir yolo_labelme
+```
+
+Notes:
+
+- COCO input should be a directory containing `*.json` files with standard `images`, `annotations`, and `categories` keys.
+- LabelMe input should be a directory containing one JSON file per image.
+- `--save-dir` controls the output directory and is deleted/recreated on each run.
+- Image files are copied for LabelMe when `imagePath` points to an existing local file next to the JSON.
+- Labelbox exports can be JSON lists or newline-delimited JSON. Bounding-box objects are converted; mask-only objects are skipped with a warning.
+
+The output follows the Ultralytics YOLO dataset layout:
+
+```text
+yolo_out/
+├── data.yaml
+├── images/
+└── labels/
 ```
 
 ## 📚 Citation

--- a/general_json2yolo.py
+++ b/general_json2yolo.py
@@ -244,7 +244,7 @@ def convert_ath_json(json_dir, save_dir="new_dir"):  # dir contains json annotat
 
     nm = len(missing_images)  # number missing
     print(
-        f"\nFound {len(jsons):g} JSONs with {n3:g} labels over {n1:g} images. Found {n1 - nm:g} images, labelled {n2:g} images successfully"
+        f"\nFound {len(jsons):g} JSONs with {n3:g} labels over {n1:g} images. Found {n1 - nm:g} images, labeled {n2:g} images successfully"
     )
     if len(missing_images):
         print("WARNING, missing images:", missing_images)
@@ -313,7 +313,7 @@ def convert_coco_json(
                 cls = coco80[ann["category_id"] - 1] if cls91to80 else ann["category_id"] - 1  # class
                 if cls is None:
                     continue
-                box = [cls] + box.tolist()
+                box = [cls, *box.tolist()]
                 if box not in bboxes:
                     bboxes.append(box)
                 else:
@@ -331,7 +331,7 @@ def convert_coco_json(
                         s = (np.array(s).reshape(-1, 2) / np.array([w, h])).reshape(-1).tolist()
                     else:
                         s = []
-                    segments.append([cls] + s if s else [])
+                    segments.append([cls, *s] if s else [])
                 if use_keypoints:
                     keypoints.append(box + coco_keypoints(ann, w, h))
 
@@ -340,13 +340,7 @@ def convert_coco_json(
             label_file.parent.mkdir(parents=True, exist_ok=True)
             with open(label_file, "a") as file:
                 for i in range(len(bboxes)):
-                    line = (
-                        keypoints[i]
-                        if use_keypoints
-                        else segments[i]
-                        if use_segments and segments[i]
-                        else bboxes[i]
-                    )
+                    line = keypoints[i] if use_keypoints else segments[i] if use_segments and segments[i] else bboxes[i]
                     line = tuple(line)
                     file.write(("%g " * len(line)).rstrip() % line + "\n")
     return save_dir
@@ -385,12 +379,12 @@ def convert_labelme_json(json_dir, use_segments=True, save_dir="new_dir"):
             shape_type = shape.get("shape_type", "polygon")
             segment = yolo_segment(points, width, height)
             if use_segments and shape_type in {"polygon", "linestrip"} and segment:
-                line = [cls] + segment
+                line = [cls, *segment]
             else:
                 box = yolo_bbox(points, width, height)
                 if not box:
                     continue
-                line = [cls] + box
+                line = [cls, *box]
             lines.append(("%g " * len(line)).rstrip() % tuple(line))
 
         if lines:
@@ -517,14 +511,13 @@ def coco_names(data, coco80, cls91to80):
 
 
 def min_index(arr1, arr2):
-    """
-    Find a pair of indexes with the shortest distance.
+    """Find a pair of indexes with the shortest distance.
 
     Args:
         arr1: (N, 2).
         arr2: (M, 2).
 
-    Return:
+    Returns:
         a pair of indexes(tuple).
     """
     dis = ((arr1[:, None, :] - arr2[None, :, :]) ** 2).sum(-1)
@@ -532,14 +525,12 @@ def min_index(arr1, arr2):
 
 
 def merge_multi_segment(segments):
-    """
-    Merge multi segments to one list. Find the coordinates with min distance between each segment, then connect these
+    """Merge multi segments to one list. Find the coordinates with min distance between each segment, then connect these
     coordinates with one thin line to merge all segments into one.
 
     Args:
-        segments(List(List)): original segmentations in coco's json file.
-            like [segmentation1, segmentation2,...],
-            each segmentation is a list of coordinates.
+        segments(List(List)): original segmentations in coco's json file. like [segmentation1, segmentation2,...], each
+            segmentation is a list of coordinates.
     """
     s = []
     segments = [np.array(i).reshape(-1, 2) for i in segments]

--- a/general_json2yolo.py
+++ b/general_json2yolo.py
@@ -280,7 +280,6 @@ def convert_coco_json(
             print(f"WARNING: Skipping {json_file}, expected COCO keys 'images' and 'annotations'.")
             continue
         write_coco_yaml(Path(save_dir) / f"{json_file.stem}.yaml", data, coco80, cls91to80)
-        write_dataset_yaml(Path(save_dir) / "data.yaml", coco_names(data, coco80, cls91to80))
 
         # Create image dict
         images = {"{:g}".format(x["id"]): x for x in data["images"]}
@@ -364,7 +363,9 @@ def convert_labelme_json(json_dir, use_segments=True, save_dir="new_dir"):
             continue
 
         image_name = data.get("imagePath") or json_file.with_suffix(".jpg").name
-        label_file = (save_dir / "labels" / Path(image_name)).with_suffix(".txt")
+        image_file = labelme_image_file(json_file, image_name)
+        output_name = safe_relative_path(image_name, json_file.with_suffix(".jpg").name)
+        label_file = (save_dir / "labels" / output_name).with_suffix(".txt")
         label_file.parent.mkdir(parents=True, exist_ok=True)
         lines = []
         for shape in data.get("shapes", []):
@@ -378,7 +379,7 @@ def convert_labelme_json(json_dir, use_segments=True, save_dir="new_dir"):
 
             shape_type = shape.get("shape_type", "polygon")
             segment = yolo_segment(points, width, height)
-            if use_segments and shape_type in {"polygon", "linestrip"} and segment:
+            if use_segments and shape_type in {"polygon", "linestrip", "mask"} and segment:
                 line = [cls, *segment]
             else:
                 box = yolo_bbox(points, width, height)
@@ -391,15 +392,30 @@ def convert_labelme_json(json_dir, use_segments=True, save_dir="new_dir"):
             label_file.write_text("\n".join(lines) + "\n")
             converted += 1
 
-        image_file = json_file.parent / image_name
         if image_file.exists():
-            output_image = save_dir / "images" / Path(image_name)
+            output_image = save_dir / "images" / output_name
             output_image.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(image_file, output_image)
 
     write_dataset_yaml(save_dir / "data.yaml", names)
     print(f"Done. Converted {converted:g}/{len(json_files):g} LabelMe JSON files to {save_dir}")
     return save_dir
+
+
+def safe_relative_path(path, fallback):
+    """Returns a safe relative path for writing inside an output directory."""
+    raw = str(path or fallback).replace("\\", "/")
+    path = Path(raw)
+    if path.is_absolute() or ".." in path.parts:
+        return Path(path.name or fallback)
+    parts = [part for part in path.parts if part not in {"", "."}]
+    return Path(*parts) if parts else Path(fallback)
+
+
+def labelme_image_file(json_file, image_name):
+    """Returns the local image path referenced by a LabelMe JSON file."""
+    path = Path(str(image_name).replace("\\", "/"))
+    return path if path.is_absolute() else json_file.parent / path
 
 
 def labelme_points(shape, width, height):

--- a/general_json2yolo.py
+++ b/general_json2yolo.py
@@ -1,8 +1,11 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import argparse
+import base64
 import contextlib
+import io
 import json
+import shutil
 from collections import defaultdict
 from pathlib import Path
 
@@ -142,9 +145,9 @@ def convert_vott_json(name, files, img_path):
 
 
 # Convert ath JSON file into YOLO-format labels --------------------------------
-def convert_ath_json(json_dir):  # dir contains json annotations and images
+def convert_ath_json(json_dir, save_dir="new_dir"):  # dir contains json annotations and images
     """Converts ath JSON annotations to YOLO-format labels, resizes images, and organizes data for training."""
-    dir = make_dirs()  # output directory
+    dir = make_dirs(save_dir)  # output directory
 
     jsons = []
     for dirpath, dirnames, filenames in os.walk(json_dir):
@@ -257,18 +260,27 @@ def convert_ath_json(json_dir):  # dir contains json annotations and images
     print(f"Done. Output saved to {Path(dir).absolute()}")
 
 
-def convert_coco_json(json_dir="../coco/annotations/", use_segments=False, use_keypoints=False, cls91to80=False):
+def convert_coco_json(
+    json_dir="../coco/annotations/", use_segments=False, use_keypoints=False, cls91to80=False, save_dir="new_dir"
+):
     """Converts COCO JSON format to YOLO label format, with options for segments, keypoints, and class mapping."""
-    save_dir = make_dirs()  # output directory
+    save_dir = make_dirs(save_dir)  # output directory
     coco80 = coco91_to_coco80_class()
+    json_files = sorted(Path(json_dir).resolve().glob("*.json"))
+    if not json_files:
+        raise FileNotFoundError(f"No JSON files found in {Path(json_dir).resolve()}")
 
     # Import json
-    for json_file in sorted(Path(json_dir).resolve().glob("*.json")):
+    for json_file in json_files:
         fn = Path(save_dir) / "labels" / json_file.stem.replace("instances_", "")  # folder name
-        fn.mkdir()
+        fn.mkdir(parents=True, exist_ok=True)
         with open(json_file) as f:
             data = json.load(f)
+        if not {"images", "annotations"}.issubset(data):
+            print(f"WARNING: Skipping {json_file}, expected COCO keys 'images' and 'annotations'.")
+            continue
         write_coco_yaml(Path(save_dir) / f"{json_file.stem}.yaml", data, coco80, cls91to80)
+        write_dataset_yaml(Path(save_dir) / "data.yaml", coco_names(data, coco80, cls91to80))
 
         # Create image dict
         images = {"{:g}".format(x["id"]): x for x in data["images"]}
@@ -287,6 +299,8 @@ def convert_coco_json(json_dir="../coco/annotations/", use_segments=False, use_k
             keypoints = []
             for ann in anns:
                 if ann.get("iscrowd", False):
+                    continue
+                if "category_id" not in ann:
                     continue
                 # The COCO box format is [top left x, top left y, width, height]
                 box = np.array(ann.get("bbox") or bbox_from_keypoints(ann), dtype=np.float64)
@@ -335,6 +349,125 @@ def convert_coco_json(json_dir="../coco/annotations/", use_segments=False, use_k
                     )
                     line = tuple(line)
                     file.write(("%g " * len(line)).rstrip() % line + "\n")
+    return save_dir
+
+
+def convert_labelme_json(json_dir, use_segments=True, save_dir="new_dir"):
+    """Converts LabelMe JSON annotations to YOLO detection or segmentation labels."""
+    save_dir = make_dirs(save_dir)
+    json_files = sorted(Path(json_dir).resolve().rglob("*.json"))
+    if not json_files:
+        raise FileNotFoundError(f"No JSON files found in {Path(json_dir).resolve()}")
+
+    names = []
+    converted = 0
+    for json_file in tqdm(json_files, desc="LabelMe"):
+        with open(json_file) as f:
+            data = json.load(f)
+        width, height = data.get("imageWidth"), data.get("imageHeight")
+        if not width or not height:
+            print(f"WARNING: Skipping {json_file}, missing imageWidth/imageHeight.")
+            continue
+
+        image_name = data.get("imagePath") or json_file.with_suffix(".jpg").name
+        label_file = (save_dir / "labels" / Path(image_name)).with_suffix(".txt")
+        label_file.parent.mkdir(parents=True, exist_ok=True)
+        lines = []
+        for shape in data.get("shapes", []):
+            label = shape.get("label", "object")
+            if label not in names:
+                names.append(label)
+            cls = names.index(label)
+            points = labelme_points(shape, width, height)
+            if len(points) < 2:
+                continue
+
+            shape_type = shape.get("shape_type", "polygon")
+            segment = yolo_segment(points, width, height)
+            if use_segments and shape_type in {"polygon", "linestrip"} and segment:
+                line = [cls] + segment
+            else:
+                box = yolo_bbox(points, width, height)
+                if not box:
+                    continue
+                line = [cls] + box
+            lines.append(("%g " * len(line)).rstrip() % tuple(line))
+
+        if lines:
+            label_file.write_text("\n".join(lines) + "\n")
+            converted += 1
+
+        image_file = json_file.parent / image_name
+        if image_file.exists():
+            output_image = save_dir / "images" / Path(image_name)
+            output_image.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(image_file, output_image)
+
+    write_dataset_yaml(save_dir / "data.yaml", names)
+    print(f"Done. Converted {converted:g}/{len(json_files):g} LabelMe JSON files to {save_dir}")
+    return save_dir
+
+
+def labelme_points(shape, width, height):
+    """Returns LabelMe shape points, including decoded mask contours when available."""
+    points = shape.get("points", [])
+    if shape.get("shape_type") == "mask" and shape.get("mask"):
+        mask_points = mask2points(shape["mask"], points, width, height)
+        if mask_points:
+            return mask_points
+    if shape.get("shape_type") == "circle" and len(points) >= 2:
+        center, edge = np.array(points[0], dtype=np.float64), np.array(points[1], dtype=np.float64)
+        r = np.linalg.norm(edge - center)
+        return [[center[0] - r, center[1] - r], [center[0] + r, center[1] + r]]
+    return points
+
+
+def mask2points(mask_data, points, width, height):
+    """Converts a LabelMe base64 mask to polygon points."""
+    mask = np.array(Image.open(io.BytesIO(base64.b64decode(mask_data))).convert("L"))
+    if mask.shape[:2] != (height, width) and len(points):
+        full_mask = np.zeros((height, width), dtype=np.uint8)
+        x, y = np.array(points, dtype=np.float64).min(axis=0).astype(int)
+        h, w = mask.shape[:2]
+        full_mask[y : y + h, x : x + w] = mask
+        mask = full_mask
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_TC89_KCOS)
+    if not contours:
+        return []
+    contour = max(contours, key=cv2.contourArea)
+    return cv2.approxPolyDP(contour, 0.001 * cv2.arcLength(contour, True), True).reshape(-1, 2).tolist()
+
+
+def yolo_bbox(points, width, height):
+    """Converts shape points to normalized YOLO xywh."""
+    points = np.array(points, dtype=np.float64).reshape(-1, 2)
+    x, y = points[:, 0], points[:, 1]
+    box = [
+        (x.min() + x.max()) / 2 / width,
+        (y.min() + y.max()) / 2 / height,
+        (x.max() - x.min()) / width,
+        (y.max() - y.min()) / height,
+    ]
+    return box if box[2] > 0 and box[3] > 0 else []
+
+
+def yolo_segment(points, width, height):
+    """Converts polygon points to normalized YOLO segmentation coordinates."""
+    points = np.array(points, dtype=np.float64).reshape(-1, 2)
+    if len(points) < 3:
+        return []
+    return (points / np.array([width, height])).reshape(-1).tolist()
+
+
+def write_dataset_yaml(file, names):
+    """Writes a YOLO dataset YAML with class names."""
+    names = names if isinstance(names, dict) else dict(enumerate(names))
+    with open(file, "w") as f:
+        yaml.safe_dump(
+            {"path": str(file.parent), "train": "images", "val": "images", "names": names},
+            f,
+            sort_keys=False,
+        )
 
 
 def bbox_from_keypoints(ann):
@@ -367,14 +500,20 @@ def rle2polygon(segmentation):
 
 def write_coco_yaml(file, data, coco80, cls91to80):
     """Writes class id-to-name metadata from COCO categories."""
+    names = coco_names(data, coco80, cls91to80)
+    if names:
+        with open(file, "w") as f:
+            yaml.safe_dump({"names": names}, f, sort_keys=False)
+
+
+def coco_names(data, coco80, cls91to80):
+    """Returns class id-to-name metadata from COCO categories."""
     names = {}
     for category in data.get("categories", []):
         class_id = coco80[category["id"] - 1] if cls91to80 else category["id"] - 1
         if class_id is not None:
             names[int(class_id)] = category["name"]
-    if names:
-        with open(file, "w") as f:
-            yaml.safe_dump({"names": dict(sorted(names.items()))}, f, sort_keys=False)
+    return dict(sorted(names.items()))
 
 
 def min_index(arr1, arr2):
@@ -454,8 +593,11 @@ def delete_dsstore(path="../datasets"):
 def parse_args():
     """Parses command-line arguments for legacy standalone conversion."""
     parser = argparse.ArgumentParser(description="Convert JSON annotations to YOLO labels.")
-    parser.add_argument("--source", default="COCO", choices=["COCO", "infolks", "vott", "ath"], help="Input format.")
+    parser.add_argument(
+        "--source", default="COCO", choices=["COCO", "LabelMe", "infolks", "vott", "ath"], help="Input format."
+    )
     parser.add_argument("--json-dir", default="../datasets/coco/annotations", help="Directory containing JSON files.")
+    parser.add_argument("--save-dir", default="new_dir", help="Output directory.")
     parser.add_argument("--use-segments", action="store_true", help="Export COCO segmentation labels.")
     parser.add_argument("--use-keypoints", action="store_true", help="Export COCO keypoint labels.")
     parser.add_argument("--cls91to80", action="store_true", help="Map COCO 91-category ids to 80-category ids.")
@@ -468,13 +610,15 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
     if args.source == "COCO":
-        convert_coco_json(args.json_dir, args.use_segments, args.use_keypoints, args.cls91to80)
+        convert_coco_json(args.json_dir, args.use_segments, args.use_keypoints, args.cls91to80, args.save_dir)
+    elif args.source == "LabelMe":
+        convert_labelme_json(args.json_dir, args.use_segments, args.save_dir)
     elif args.source == "infolks":
         convert_infolks_json(name=args.name, files=args.files, img_path=args.img_path)
     elif args.source == "vott":
         convert_vott_json(name=args.name, files=args.files, img_path=args.img_path)
     elif args.source == "ath":
-        convert_ath_json(json_dir=args.json_dir)
+        convert_ath_json(json_dir=args.json_dir, save_dir=args.save_dir)
 
     # zip results
     # os.system('zip -r ../coco.zip ../coco')

--- a/labelbox_json2yolo.py
+++ b/labelbox_json2yolo.py
@@ -17,10 +17,11 @@ def convert(file, zip=True):
     names = []  # class names
     file = Path(file)
     save_dir = make_dirs(file.stem)
-    with open(file) as f:
-        data = json.load(f)  # load JSON
+    data = load_labelbox_json(file)
 
     for img in tqdm(data, desc=f"Converting {file}"):
+        if not isinstance(img, dict):
+            raise TypeError(f"Expected Labelbox record dictionaries, got {type(img).__name__} in {file}")
         im_path = img["Labeled Data"]
         im = Image.open(requests.get(im_path, stream=True).raw if im_path.startswith("http") else im_path)  # open
         width, height = im.size  # image size
@@ -29,6 +30,9 @@ def convert(file, zip=True):
         im.save(image_path, quality=95, subsampling=0)
 
         for label in img["Label"]["objects"]:
+            if "bbox" not in label:
+                print(f"WARNING: Skipping non-bbox Labelbox object in {img.get('External ID', file.name)}.")
+                continue
             # box
             top, left, h, w = label["bbox"].values()  # top, left, height, width
             xywh = [(left + w / 2) / width, (top + h / 2) / height, w / width, h / height]  # xywh normalized
@@ -61,6 +65,18 @@ def convert(file, zip=True):
         os.system(f"zip -qr {save_dir}.zip {save_dir}")
 
     print("Conversion completed successfully!")
+
+
+def load_labelbox_json(file):
+    """Loads Labelbox JSON list, JSON object, or newline-delimited JSON export."""
+    text = Path(file).read_text().strip()
+    if not text:
+        return []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        data = [json.loads(line) for line in text.splitlines() if line.strip()]
+    return data if isinstance(data, list) else [data]
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ pycocotools
 pyYAML
 requests
 tqdm
-argparse

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,100 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from general_json2yolo import convert_coco_json, convert_labelme_json
+from labelbox_json2yolo import load_labelbox_json
+
+
+def test_coco_conversion_writes_nested_labels_and_yaml(tmp_path):
+    annotations = tmp_path / "annotations"
+    annotations.mkdir()
+    (annotations / "instances_train.json").write_text(
+        json.dumps(
+            {
+                "images": [{"id": 1, "height": 100, "width": 200, "file_name": "nested/image1.jpg"}],
+                "categories": [{"id": 1, "name": "person"}],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 1,
+                        "bbox": [10, 20, 40, 30],
+                        "segmentation": [[10, 20, 50, 20, 50, 50, 10, 50]],
+                    }
+                ],
+            }
+        )
+    )
+
+    save_dir = convert_coco_json(annotations, use_segments=True, save_dir=tmp_path / "out")
+
+    label = (save_dir / "labels" / "train" / "nested" / "image1.txt").read_text().strip()
+    assert label == "0 0.05 0.2 0.25 0.2 0.25 0.5 0.05 0.5"
+    assert yaml.safe_load((save_dir / "instances_train.yaml").read_text()) == {"names": {0: "person"}}
+
+
+def test_coco_conversion_writes_keypoints(tmp_path):
+    annotations = tmp_path / "annotations"
+    annotations.mkdir()
+    (annotations / "person_keypoints_val.json").write_text(
+        json.dumps(
+            {
+                "images": [{"id": 1, "height": 100, "width": 200, "file_name": "image1.jpg"}],
+                "categories": [{"id": 1, "name": "person"}],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 1,
+                        "keypoints": [20, 30, 2, 40, 50, 2],
+                    }
+                ],
+            }
+        )
+    )
+
+    save_dir = convert_coco_json(annotations, use_keypoints=True, save_dir=tmp_path / "out")
+
+    label = (save_dir / "labels" / "person_keypoints_val" / "image1.txt").read_text().strip().split()
+    assert label == ["0", "0.15", "0.4", "0.1", "0.2", "0.1", "0.3", "2", "0.2", "0.5", "2"]
+
+
+def test_labelme_conversion_writes_segments_boxes_and_yaml(tmp_path):
+    image = tmp_path / "images" / "image1.jpg"
+    image.parent.mkdir()
+    image.write_bytes(b"fake image bytes")
+    (tmp_path / "ann.json").write_text(
+        json.dumps(
+            {
+                "imagePath": "images/image1.jpg",
+                "imageHeight": 100,
+                "imageWidth": 200,
+                "shapes": [
+                    {"label": "lane", "shape_type": "polygon", "points": [[10, 20], [50, 20], [50, 60]]},
+                    {"label": "sign", "shape_type": "rectangle", "points": [[80, 10], [120, 30]]},
+                ],
+            }
+        )
+    )
+
+    save_dir = convert_labelme_json(tmp_path, use_segments=True, save_dir=tmp_path / "out")
+
+    lines = (save_dir / "labels" / "images" / "image1.txt").read_text().strip().splitlines()
+    assert lines[0] == "0 0.05 0.2 0.25 0.2 0.25 0.6"
+    assert lines[1] == "1 0.5 0.2 0.2 0.2"
+    assert (save_dir / "images" / "images" / "image1.jpg").exists()
+    assert yaml.safe_load((save_dir / "data.yaml").read_text())["names"] == {0: "lane", 1: "sign"}
+
+
+def test_load_labelbox_ndjson(tmp_path):
+    file = tmp_path / "labelbox.json"
+    file.write_text('{"External ID": "a.jpg"}\n{"External ID": "b.jpg"}\n')
+
+    assert load_labelbox_json(file) == [{"External ID": "a.jpg"}, {"External ID": "b.jpg"}]

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,10 +1,13 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import base64
+import io
 import json
 import sys
 from pathlib import Path
 
 import yaml
+from PIL import Image
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -91,6 +94,39 @@ def test_labelme_conversion_writes_segments_boxes_and_yaml(tmp_path):
     assert lines[1] == "1 0.5 0.2 0.2 0.2"
     assert (save_dir / "images" / "images" / "image1.jpg").exists()
     assert yaml.safe_load((save_dir / "data.yaml").read_text())["names"] == {0: "lane", 1: "sign"}
+
+
+def test_labelme_conversion_sanitizes_paths_and_exports_masks_as_segments(tmp_path):
+    mask = Image.new("L", (20, 20), 0)
+    for x in range(5, 15):
+        for y in range(5, 15):
+            mask.putpixel((x, y), 255)
+    buffer = io.BytesIO()
+    mask.save(buffer, format="PNG")
+
+    (tmp_path / "ann.json").write_text(
+        json.dumps(
+            {
+                "imagePath": "../escape.jpg",
+                "imageHeight": 20,
+                "imageWidth": 20,
+                "shapes": [
+                    {
+                        "label": "food",
+                        "shape_type": "mask",
+                        "points": [[0, 0], [20, 20]],
+                        "mask": base64.b64encode(buffer.getvalue()).decode(),
+                    }
+                ],
+            }
+        )
+    )
+
+    save_dir = convert_labelme_json(tmp_path, use_segments=True, save_dir=tmp_path / "out")
+
+    label = (save_dir / "labels" / "escape.txt").read_text().strip().split()
+    assert len(label) > 5
+    assert not (tmp_path / "escape.txt").exists()
 
 
 def test_load_labelbox_ndjson(tmp_path):

--- a/utils.py
+++ b/utils.py
@@ -107,8 +107,7 @@ def image_folder2file(folder="images/"):  # from utils import *; image_folder2fi
 
 
 def add_coco_background(path="../data/sm4/", n=1000):  # from utils import *; add_coco_background()
-    """
-    Adds COCO dataset background images to a specified folder and lists them in outb.txt; usage:
+    """Adds COCO dataset background images to a specified folder and lists them in outb.txt; usage:.
 
     `add_coco_background('path/', 1000)`.
     """
@@ -136,8 +135,7 @@ def create_single_class_dataset(path="../data/sm3"):  # from utils import *; cre
 
 
 def flatten_recursive_folders(path="../../Downloads/data/sm4/"):  # from utils import *; flatten_recursive_folders()
-    """Flattens nested folders in 'path/images' and 'path/json' into single 'images_flat' and 'json_flat'
-    directories.
+    """Flattens nested folders in 'path/images' and 'path/json' into single 'images_flat' and 'json_flat' directories.
     """
     idir, _jdir = f"{path}images/", f"{path}json/"
     nidir, njdir = Path(f"{path}images_flat/"), Path(f"{path}json_flat/")


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds automated testing and CI ✅, expands standalone JSON2YOLO conversion with LabelMe support 🏷️, improves COCO and Labelbox handling 🔄, and makes output control more flexible with customizable save directories 📁.

### 📊 Key Changes
- Added a new **GitHub Actions CI workflow** to automatically install dependencies, compile Python files, and run tests on pushes, pull requests, and daily schedules 🤖
- Added a full **test suite** covering:
  - COCO conversion outputs
  - keypoint export behavior
  - LabelMe conversion
  - path sanitization/security checks
  - Labelbox newline-delimited JSON loading 🧪
- Expanded `general_json2yolo.py` with **LabelMe conversion support**:
  - supports polygon, rectangle, circle, linestrip, and mask annotations
  - can export either detection boxes or segmentation labels
  - writes a YOLO-style `data.yaml`
  - copies referenced images when available 🖼️
- Improved **COCO conversion**:
  - added `save_dir` support for custom output locations
  - validates that JSON files exist and contain expected COCO fields
  - safely skips malformed annotations, such as missing `category_id`
  - preserves nested image paths in output labels 📂
- Improved **Labelbox conversion**:
  - added support for standard JSON, single-object JSON, and newline-delimited JSON exports
  - skips unsupported non-bounding-box objects with a warning ⚠️
- Updated the **README** with clearer guidance:
  - recommends using the maintained converter in the `ultralytics` package for new projects
  - documents legacy standalone usage more clearly
  - adds examples for COCO, segmentation, keypoints, and LabelMe workflows 📘
- Minor cleanup:
  - removed unnecessary `argparse` from `requirements.txt`
  - polished some docstrings and wording ✨

### 🎯 Purpose & Impact
- Makes the repository more **reliable and maintainable** by adding CI and tests, helping catch issues earlier 🚀
- Broadens format support so users can convert **more annotation types**, especially from LabelMe, without writing custom scripts 🧰
- Improves **robustness** when working with imperfect datasets by skipping bad records gracefully instead of failing outright 🛡️
- Gives users more control over where outputs are written with the new `--save-dir` option, making the converter easier to fit into existing workflows 📁
- Improves usability for both new and existing users through clearer documentation and more complete examples 🙌
- Overall, this PR makes JSON2YOLO a more practical and dependable tool for dataset conversion across common labeling platforms 🔁