### PR TITLE
Fix legacy converter path handling

### DIFF
--- a/general_json2yolo.py
+++ b/general_json2yolo.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from pathlib import Path
 
 import cv2
-import pandas as pd
 import yaml
 from PIL import Image
 
@@ -18,9 +17,9 @@ from utils import *
 
 
 # Convert INFOLKS JSON file into YOLO-format labels ----------------------------
-def convert_infolks_json(name, files, img_path):
+def convert_infolks_json(name, files, img_path, save_dir="new_dir"):
     """Converts INFOLKS JSON annotations to YOLO-format labels."""
-    path = make_dirs()
+    path = make_dirs(save_dir)
 
     # Import json
     data = []
@@ -31,7 +30,7 @@ def convert_infolks_json(name, files, img_path):
             data.append(jdata)
 
     # Write images and shapes
-    name = path + os.sep + name
+    name = path / name
     _file_id, file_name, wh, cat = [], [], [], []
     for x in tqdm(data, desc="Files and Shapes"):
         f = glob.glob(img_path + Path(x["json_file"]).stem + ".*")[0]
@@ -40,20 +39,20 @@ def convert_infolks_json(name, files, img_path):
         cat.extend(a["classTitle"].lower() for a in x["output"]["objects"])  # categories
 
         # filename
-        with open(name + ".txt", "a") as file:
+        with open(name.with_suffix(".txt"), "a") as file:
             file.write(f"{f}\n")
 
     # Write *.names file
     names = sorted(np.unique(cat))
     # names.pop(names.index('Missing product'))  # remove
-    with open(name + ".names", "a") as file:
+    with open(name.with_suffix(".names"), "a") as file:
         [file.write(f"{a}\n") for a in names]
 
     # Write labels file
     for i, x in enumerate(tqdm(data, desc="Annotations")):
         label_name = Path(file_name[i]).stem + ".txt"
 
-        with open(path + "/labels/" + label_name, "a") as file:
+        with open(path / "labels" / label_name, "a") as file:
             for a in x["output"]["objects"]:
                 # if a['classTitle'] == 'Missing product':
                 #    continue  # skip
@@ -70,15 +69,15 @@ def convert_infolks_json(name, files, img_path):
 
     # Split data into train, test, and validate files
     split_files(name, file_name)
-    write_data_data(name + ".data", nc=len(names))
-    print(f"Done. Output saved to {os.getcwd() + os.sep + path}")
+    write_data_data(name.with_suffix(".data"), nc=len(names))
+    print(f"Done. Output saved to {path.absolute()}")
 
 
 # Convert vott JSON file into YOLO-format labels -------------------------------
-def convert_vott_json(name, files, img_path):
+def convert_vott_json(name, files, img_path, save_dir="new_dir"):
     """Converts VoTT JSON files to YOLO-format labels and organizes dataset structure."""
-    path = make_dirs()
-    name = path + os.sep + name
+    path = make_dirs(save_dir)
+    name = path / name
 
     # Import json
     data = []
@@ -95,8 +94,8 @@ def convert_vott_json(name, files, img_path):
             cat.extend(a["tags"][0] for a in x["regions"])  # categories
 
     # Write *.names file
-    names = sorted(pd.unique(cat))
-    with open(name + ".names", "a") as file:
+    names = sorted(set(cat))
+    with open(name.with_suffix(".names"), "a") as file:
         [file.write(f"{a}\n") for a in names]
 
     # Write labels file
@@ -114,18 +113,18 @@ def convert_vott_json(name, files, img_path):
                 n2 += 1
 
                 # append filename to list
-                with open(name + ".txt", "a") as file:
+                with open(name.with_suffix(".txt"), "a") as file:
                     file.write(f"{f}\n")
 
                 # write labelsfile
                 label_name = Path(f).stem + ".txt"
-                with open(path + "/labels/" + label_name, "a") as file:
+                with open(path / "labels" / label_name, "a") as file:
                     for a in x["regions"]:
                         category_id = names.index(a["tags"][0])
 
                         # The INFOLKS bounding box format is [x-min, y-min, x-max, y-max]
                         box = a["boundingBox"]
-                        box = np.array([box["left"], box["top"], box["width"], box["height"]]).ravel()
+                        box = np.array([box["left"], box["top"], box["width"], box["height"]], dtype=np.float32).ravel()
                         box[[0, 2]] /= wh[0]  # normalize x by width
                         box[[1, 3]] /= wh[1]  # normalize y by height
                         box = [box[0] + box[2] / 2, box[1] + box[3] / 2, box[2], box[3]]  # xywh
@@ -141,7 +140,7 @@ def convert_vott_json(name, files, img_path):
 
     # Split data into train, test, and validate files
     split_files(name, file_name)
-    print(f"Done. Output saved to {os.getcwd() + os.sep + path}")
+    print(f"Done. Output saved to {path.absolute()}")
 
 
 # Convert ath JSON file into YOLO-format labels --------------------------------
@@ -184,7 +183,7 @@ def convert_ath_json(json_dir, save_dir="new_dir"):  # dir contains json annotat
 
                 n1 += 1  # all images
                 if len(f) > 0 and wh[0] > 0 and wh[1] > 0:
-                    label_file = dir + "labels/" + Path(f).stem + ".txt"
+                    label_file = dir / "labels" / f"{Path(f).stem}.txt"
 
                     nlabels = 0
                     try:
@@ -216,8 +215,7 @@ def convert_ath_json(json_dir, save_dir="new_dir"):  # dir contains json annotat
                                     nlabels += 1
 
                         if nlabels == 0:  # remove non-labelled images from dataset
-                            os.system(f"rm {label_file}")
-                            # print('no labels for %s' % f)
+                            label_file.unlink(missing_ok=True)
                             continue  # next file
 
                         # write image
@@ -229,14 +227,14 @@ def convert_ath_json(json_dir, save_dir="new_dir"):  # dir contains json annotat
                             h, w, _ = img.shape
                             img = cv2.resize(img, (int(w * r), int(h * r)), interpolation=cv2.INTER_AREA)
 
-                        ifile = dir + "images/" + Path(f).name
-                        if cv2.imwrite(ifile, img):  # if success append image to list
-                            with open(dir + "data.txt", "a") as file:
+                        ifile = dir / "images" / Path(f).name
+                        if cv2.imwrite(str(ifile), img):  # if success append image to list
+                            with open(dir / "data.txt", "a") as file:
                                 file.write(f"{ifile}\n")
                             n2 += 1  # correct images
 
                     except Exception:
-                        os.system(f"rm {label_file}")
+                        label_file.unlink(missing_ok=True)
                         print(f"problem with {f}")
 
             else:
@@ -251,12 +249,12 @@ def convert_ath_json(json_dir, save_dir="new_dir"):  # dir contains json annotat
 
     # Write *.names file
     names = ["knife"]  # preserves sort order
-    with open(dir + "data.names", "w") as f:
+    with open(dir / "data.names", "w") as f:
         [f.write(f"{a}\n") for a in names]
 
     # Split data into train, test, and validate files
-    split_rows_simple(dir + "data.txt")
-    write_data_data(dir + "data.data", nc=1)
+    split_rows_simple(dir / "data.txt")
+    write_data_data(dir / "data.data", nc=1)
     print(f"Done. Output saved to {Path(dir).absolute()}")
 
 
@@ -621,9 +619,9 @@ if __name__ == "__main__":
     elif args.source == "LabelMe":
         convert_labelme_json(args.json_dir, args.use_segments, args.save_dir)
     elif args.source == "infolks":
-        convert_infolks_json(name=args.name, files=args.files, img_path=args.img_path)
+        convert_infolks_json(name=args.name, files=args.files, img_path=args.img_path, save_dir=args.save_dir)
     elif args.source == "vott":
-        convert_vott_json(name=args.name, files=args.files, img_path=args.img_path)
+        convert_vott_json(name=args.name, files=args.files, img_path=args.img_path, save_dir=args.save_dir)
     elif args.source == "ath":
         convert_ath_json(json_dir=args.json_dir, save_dir=args.save_dir)
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from general_json2yolo import convert_coco_json, convert_labelme_json
+from general_json2yolo import convert_coco_json, convert_labelme_json, convert_vott_json
 from labelbox_json2yolo import load_labelbox_json
 
 
@@ -134,3 +134,25 @@ def test_load_labelbox_ndjson(tmp_path):
     file.write_text('{"External ID": "a.jpg"}\n{"External ID": "b.jpg"}\n')
 
     assert load_labelbox_json(file) == [{"External ID": "a.jpg"}, {"External ID": "b.jpg"}]
+
+
+def test_vott_conversion_uses_path_outputs(tmp_path):
+    images = tmp_path / "images"
+    images.mkdir()
+    Image.new("RGB", (200, 100)).save(images / "image1.jpg")
+    json_file = tmp_path / "vott.json"
+    json_file.write_text(
+        json.dumps(
+            {
+                "asset": {"name": "image1"},
+                "regions": [
+                    {"tags": ["cat"], "boundingBox": {"left": 10, "top": 20, "width": 40, "height": 30}}
+                ],
+            }
+        )
+    )
+
+    save_dir = tmp_path / "out"
+    convert_vott_json("data", str(tmp_path / "*.json"), f"{images}/", save_dir=save_dir)
+
+    assert (save_dir / "labels" / "image1.txt").read_text().strip() == "0 0.150000 0.350000 0.200000 0.300000"

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -145,9 +145,7 @@ def test_vott_conversion_uses_path_outputs(tmp_path):
         json.dumps(
             {
                 "asset": {"name": "image1"},
-                "regions": [
-                    {"tags": ["cat"], "boundingBox": {"left": 10, "top": 20, "width": 40, "height": 30}}
-                ],
+                "regions": [{"tags": ["cat"], "boundingBox": {"left": 10, "top": 20, "width": 40, "height": 30}}],
             }
         )
     )


### PR DESCRIPTION
## Summary\n- fix Path + str failures in legacy Infolks, VoTT, and ath converters\n- pass --save-dir through Infolks and VoTT CLI paths\n- remove the now-unused pandas import from general_json2yolo.py\n- add a VoTT regression test for Path output handling\n\n## Issues\nFixes #30\n\n## Tests\n- python -m compileall -q .\n- pytest -q\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves JSON2YOLO’s file handling and output flexibility, making conversions more reliable, cleaner, and easier to test.

### 📊 Key Changes
- Added a `save_dir` parameter to `convert_infolks_json()` and `convert_vott_json()` so users can choose where converted YOLO files are saved 📁
- Replaced many string-based path operations with `Path` objects for safer, more consistent cross-platform file handling ✅
- Removed the `pandas` dependency from VoTT conversion by switching from `pd.unique(cat)` to `sorted(set(cat))` ⚡
- Updated output file creation to use `Path.with_suffix()` and path joins like `path / "labels" / label_name`, improving code clarity and robustness
- Improved cleanup in ATH conversion by replacing shell-based file deletion (`rm`) with Python-native `unlink()` 🧹
- Ensured image writing in ATH conversion uses a proper string path when calling OpenCV’s `cv2.imwrite()`
- Added a new test to confirm VoTT conversion writes labels to the expected output directory and produces the correct YOLO annotation format 🧪
- Updated CLI argument handling so `--save_dir` now correctly applies to Infolks and VoTT conversions too

### 🎯 Purpose & Impact
- Makes the converter more user-friendly by letting users control output locations instead of relying on a fixed default folder 🎯
- Improves portability across operating systems by avoiding fragile manual path concatenation and shell commands 🌍
- Reduces dependencies and simplifies setup by removing an unnecessary `pandas` import 📦
- Lowers the risk of path-related bugs and file write issues, especially in automated workflows and testing 🔒
- Strengthens confidence in VoTT conversion behavior through test coverage, which should help catch regressions earlier 🚦
- Overall, this is a quality-of-life and reliability update rather than a feature overhaul, but it should make JSON2YOLO easier to maintain and safer to use for real-world dataset conversion workflows 🚀