### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in CI from `actions/checkout@v4` to `actions/checkout@v6` to keep the repository’s automation current.

### 📊 Key Changes
- 🛠️ Updated `.github/workflows/ci.yml`
- ⬆️ Changed the CI checkout action from `actions/checkout@v4` to `actions/checkout@v6`
- 🤖 No changes to JSON2YOLO conversion logic, features, or user-facing functionality

### 🎯 Purpose & Impact
- ✅ Keeps the CI workflow aligned with newer GitHub Actions versions and best practices
- 🔒 May improve security, compatibility, and long-term maintenance of the project’s automation
- 🚀 Helps ensure continued reliability of automated testing and validation
- 📦 Has no direct impact on how end users run or use JSON2YOLO, since this is a workflow-only update