### PR TITLE
Bump actions/setup-python from v5 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Bump actions/setup-python from v5 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use `actions/setup-python@v6` instead of `@v5`, keeping the repository’s automation up to date.

### 📊 Key Changes
- Updated the CI workflow file `.github/workflows/ci.yml`
- Changed the GitHub Action for Python setup from `actions/setup-python@v5` to `actions/setup-python@v6`
- Kept the Python version unchanged at `3.11`

### 🎯 Purpose & Impact
- Improves maintenance by aligning CI with the latest supported GitHub Action version ✅
- Helps ensure continued compatibility, security, and reliability in automated testing 🛡️
- Has no direct effect on JSON2YOLO features or user-facing behavior; this is an internal infrastructure update only ⚙️