### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ If you find our tool useful for your research or development, please consider ci
 
 We welcome contributions from the community! Whether you're fixing bugs, adding new features, or improving documentation, your input is invaluable. Take a look at our [Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started. Also, we'd love to hear about your experience with Ultralytics products. Please consider filling out our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey). A huge 🙏 and thank you to all of our contributors!
 
-[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
+[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/JSON2YOLO/graphs/contributors)
 
 ## ©️ License
 
 Ultralytics offers two licensing options to accommodate diverse needs:
 
-- **AGPL-3.0 License**: Ideal for students and enthusiasts, this [OSI-approved](https://opensource.org/license/agpl-v3) open-source license promotes collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) file for details.
+- **AGPL-3.0 License**: Ideal for students and enthusiasts, this [OSI-approved](https://opensource.org/license/agpl-v3) open-source license promotes collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/JSON2YOLO/blob/main/LICENSE) file for details.
 - **Enterprise License**: Designed for commercial use, this license permits seamless integration of Ultralytics software and AI models into commercial products and services, bypassing the open-source requirements of AGPL-3.0. For commercial inquiries, please contact us through [Ultralytics Licensing](https://www.ultralytics.com/license).
 
 ## 📬 Contact Us


### PR DESCRIPTION
## Summary
- retargets the contributors image link to this repository
- points the AGPL license reference at this repository's LICENSE file
- preserves existing README badges and linked assets

## Validation
- git diff --check
- lychee README.md

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes README links in `ultralytics/JSON2YOLO` so they point to the correct repository resources instead of the main `ultralytics` repo.

### 📊 Key Changes
- Updated the **contributors badge link** to open the `ultralytics/JSON2YOLO` contributors page.
- Updated the **AGPL-3.0 license link** to point to the `JSON2YOLO` repository’s own `LICENSE` file.
- Kept the visible README content the same while correcting the underlying destinations of the links.

### 🎯 Purpose & Impact
- Improves 📚 **documentation accuracy** by ensuring users land on the right repository pages.
- Makes it easier for contributors 🤝 to find the actual `JSON2YOLO` contributor list.
- Reduces confusion for users checking licensing details 🔒, since the link now matches the correct project.
- A small but useful maintenance update ✅ that improves trust and overall repository polish.