### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in CI from `actions/checkout@v6` to `actions/checkout@v7` to keep the automation workflow current.

### 📊 Key Changes
- 🛠️ Updated `.github/workflows/ci.yml`
- ⬆️ Changed the repository checkout action from `actions/checkout@v6` to `actions/checkout@v7`
- 🤖 No changes to JSON2YOLO source code, features, or conversion behavior

### 🎯 Purpose & Impact
- ✅ Keeps the CI pipeline aligned with the latest GitHub Actions version
- 🔒 May improve security, reliability, and long-term maintenance of automated checks
- 👥 No direct impact on end users of JSON2YOLO, but helps maintainers keep development workflows healthy and up to date