### PR TITLE
Add CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,7 +3,7 @@
 # Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 
-name: CLA Assistant
+name: CLA
 on:
   issue_comment:
     types:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,8 +2,6 @@
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 
 name: CLA Assistant
-concurrency:
-  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
 on:
   issue_comment:
     types:
@@ -20,12 +18,13 @@ permissions:
 
 jobs:
   CLA:
-    if: github.repository == 'ultralytics/JSON2YOLO' && (github.event_name != 'issue_comment' || github.event.issue.pull_request)
+    if: github.repository == 'ultralytics/JSON2YOLO' && (github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA')))
+    concurrency:
+      group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA') || github.event_name == 'pull_request_target'
-        uses: ultralytics/actions/cla@43945a7d2364fc943becb0245a4edcb05e49427f
+        uses: ultralytics/actions/cla@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cla-token: ${{ secrets._GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,31 @@
+# Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
+# This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
+
+name: CLA Assistant
+concurrency:
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+on:
+  issue_comment:
+    types:
+      - created
+  pull_request_target:
+    types:
+      - reopened
+      - opened
+      - synchronize
+
+permissions:
+  actions: write
+  pull-requests: write
+
+jobs:
+  CLA:
+    if: github.repository == 'ultralytics/JSON2YOLO' && (github.event_name != 'issue_comment' || github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA') || github.event_name == 'pull_request_target'
+        uses: ultralytics/actions/cla@43945a7d2364fc943becb0245a4edcb05e49427f
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cla-token: ${{ secrets._GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,12 +20,12 @@ permissions:
 
 jobs:
   CLA:
-    if: github.repository == 'ultralytics/JSON2YOLO' && (github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA')))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA'))
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest
     steps:
-      - name: CLA Assistant
+      - name: CLA
         uses: ultralytics/actions/cla@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- add the canonical public CLA workflow with the standard Ultralytics license header
- use `ultralytics/actions/cla@main` so repositories inherit shared fixes automatically
- route actionable events at the job boundary and grant only `actions: write` and `pull-requests: write`
- keep the ledger PAT isolated to the CLA step and central `ultralytics/cla` repository

Deleted: nothing. No CLA workflow or repository-local equivalent existed; organization-wide CLA enforcement cannot be achieved by deletion or relocation in this repository.

Reused: the canonical `ultralytics/actions/.github/workflows/cla.yml` structure and shared `ultralytics/actions/cla@main` implementation.

## Validation

- byte-for-byte comparison with the reviewed `ultralytics/actions/.github/workflows/cla.yml` template
- `actionlint .github/workflows/cla.yml`
- `npx prettier --write .github/workflows/cla.yml`
- license-header, shared-main-action, and token-input scan
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds an automated Contributor License Agreement (CLA) workflow to manage contributor sign-offs for pull requests. 🤝

### 📊 Key Changes

- Added a new `.github/workflows/cla.yml` GitHub Actions workflow.
- Automatically checks CLA status when pull requests are opened, reopened, or updated.
- Allows contributors to trigger a CLA recheck by commenting `recheck` or confirming the CLA statement.
- Uses the shared `ultralytics/actions/cla@main` action to manage CLA verification.
- Adds concurrency control to prevent overlapping CLA checks for the same pull request.

### 🎯 Purpose & Impact

- Ensures contributors complete the required Ultralytics CLA before their changes are merged. ✅
- Reduces manual maintenance for repository administrators.
- Provides a consistent and transparent contribution process for developers.
- Does not affect runtime behavior or JSON-to-YOLO conversion functionality; the impact is limited to pull request management.