### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: ultralytics/actions/setup-uv@main
 
       - name: Install dependencies
         run: uv pip install --system -r requirements.txt pytest ultralytics


### PR DESCRIPTION
## Summary
- replace all 1 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 1 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates CI to use Ultralytics’ shared `setup-uv` GitHub Action for installing `uv`.

### 📊 Key Changes

- Replaces `astral-sh/setup-uv@v5` with `ultralytics/actions/setup-uv@main` in the CI workflow.
- Keeps the existing Python 3.11 environment and dependency installation unchanged.

### 🎯 Purpose & Impact

- Centralizes `uv` setup through Ultralytics’ shared workflow tooling. ⚙️
- Simplifies maintenance and enables consistent CI configuration across Ultralytics repositories.
- CI behavior should remain functionally equivalent, with no expected changes for end users. ✅