### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the GitHub Actions Python setup action from v6 to v7 in the CI workflow. ⚙️

### 📊 Key Changes

- Replaces `actions/setup-python@v6` with `actions/setup-python@v7`.
- Keeps Python 3.11 as the CI runtime.
- No changes to application code or conversion functionality.

### 🎯 Purpose & Impact

- ✅ Keeps the CI pipeline aligned with the latest supported setup action.
- 🔒 May provide updated compatibility, maintenance, and security improvements from GitHub Actions.
- 👥 No expected impact on end users or JSON2YOLO behavior.