### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,7 @@ vid_formats = [
 ]  # acceptable video suffixes
 
 # Get orientation exif tag
-for orientation in ExifTags.TAGS.keys():
+for orientation in ExifTags.TAGS:
     if ExifTags.TAGS[orientation] == "Orientation":
         break
 
@@ -57,7 +57,7 @@ def split_rows_simple(
         lines = f.readlines()
 
     s = Path(file).suffix
-    lines = sorted(list(filter(lambda x: len(x) > 0, lines)))
+    lines = sorted(filter(lambda x: len(x) > 0, lines))
     i, j, k = split_indices(lines, train=0.9, test=0.1, validate=0.0)
     for k, v in {"train": i, "test": j, "val": k}.items():  # key, value pairs
         if v.any():
@@ -121,8 +121,7 @@ def image_folder2file(folder="images/"):  # from utils import *; image_folder2fi
     """Generates a txt file listing all images in a specified folder; usage: `image_folder2file('path/to/folder/')`."""
     s = glob.glob(f"{folder}*.*")
     with open(f"{folder[:-1]}.txt", "w") as file:
-        for image in s:
-            file.write(image + "\n")  # write image list
+        file.writelines(image + "\n" for image in s)  # write image list
 
 
 def add_coco_background(path="../data/sm4/", n=1000):  # from utils import *; add_coco_background()


### PR DESCRIPTION
## Summary
- apply Ruff 0.16.0 automatic fixes using the shared Ultralytics Actions settings
- preserve Python 3.8 targeting and the global BLE001/S110 ignores

## Validation
- `uvx --from ruff==0.16.0 ruff check --fix --unsafe-fixes ...`
- `uvx --from ruff==0.16.0 ruff format --line-length 120 .`
- `python -m compileall -q .` on Python 3.8
- `pytest -q` (6 passed)

Deleted: redundant list materialization and per-image write loop; Ruff compatibility is implemented by replacing existing expressions rather than adding a new path.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Modernizes utility code for cleaner, more efficient Python behavior without changing core functionality. 🛠️

### 📊 Key Changes

- Simplified iteration over EXIF tag keys by removing the unnecessary `.keys()` call.
- Removed an unnecessary list conversion when filtering and sorting file lines.
- Replaced a manual file-writing loop with `writelines()` and a generator expression.
- Preserved existing image-list generation, dataset splitting, and EXIF orientation handling.

### 🎯 Purpose & Impact

- Improves code readability and follows modern Python practices. ✨
- Reduces unnecessary intermediate list creation, which may modestly improve memory usage.
- Keeps the existing JSON2YOLO conversion workflows and outputs unchanged for users. ✅