### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -58,12 +58,12 @@ def split_rows_simple(
 
     s = Path(file).suffix
     lines = sorted(filter(lambda x: len(x) > 0, lines))
-    i, j, k = split_indices(lines, train=0.9, test=0.1, validate=0.0)
-    for k, v in {"train": i, "test": j, "val": k}.items():  # key, value pairs
-        if v.any():
-            new_file = file.replace(s, f"_{k}{s}")
+    train_indices, test_indices, val_indices = split_indices(lines, train=0.9, test=0.1, validate=0.0)
+    for split, indices in {"train": train_indices, "test": test_indices, "val": val_indices}.items():
+        if indices.any():
+            new_file = file.replace(s, f"_{split}{s}")
             with open(new_file, "w") as f:
-                f.writelines([lines[i] for i in v])
+                f.writelines([lines[i] for i in indices])
 
 
 def split_files(out_path, file_name, prefix_path=""):  # split training data


### PR DESCRIPTION
## Summary
- resolve the remaining B020 diagnostic hidden by the non-failing format job
- give split indices distinct owner-level names without changing output

## Validation
- pinned Ruff 0.16.0 check and format commands are clean
- Python 3.8 compileall
- pytest (6 passed)

Deleted: the loop-variable shadowing path was replaced with explicit split and index names.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improved variable naming in dataset splitting logic to make the code clearer and easier to maintain. ✨

### 📊 Key Changes

- Replaced ambiguous variable names (`i`, `j`, `k`, `v`) with descriptive names such as `train_indices`, `test_indices`, `val_indices`, `split`, and `indices`.
- Updated the output-file generation and line-selection logic to use the new names.
- Preserved the existing dataset split behavior and train/test/validation file format. ✅

### 🎯 Purpose & Impact

- Makes the code easier for developers to read, understand, and maintain. 🧑‍💻
- Reduces the risk of confusion between split names, indices, and loop variables.
- Introduces no functional changes, so existing JSON-to-YOLO conversion workflows should behave the same. 🚀