### PR TITLE
Align AGENTS.md with canonical Core Principles and PR Workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,31 +4,27 @@ This file provides guidance to AI coding agents (Claude Code, etc.) when working
 
 ## Core Principles (CRITICAL)
 
-**Delete > Replace > Add.** Before writing any change, answer in order: what can I delete? what can I replace? only then, what must I add?
+**Less is more. The simplest solution is the best solution.** The action hierarchy for every change: **Delete > Replace > Add**.
 
-The most common agent failure in this repo is reaching for the locally-safest edit — a new guard, flag, or helper — instead of fixing ownership. These tripwires override that instinct:
+1. **Solve at the owner**: Put behavior in the code path that owns or observes it. For fixes, never guard a symptom with a staleness check, initialization flag, skip-first-call branch, or `try/except` around broken logic; relocate the trigger and delete the wrong path. For features, extend the existing owner rather than creating a parallel abstraction.
+2. **Search and reuse first**: Search the whole repository before creating a feature, component, helper, workflow, or utility. Reuse or adapt what exists, consolidate in-scope duplication in the shared owner, and delete duplicate paths. Three similar lines beat a helper nobody else calls.
+3. **Delete and modify existing code before creating new code**: Bugfixes are net-negative by default unless deletion and relocation are demonstrably impossible. A new file must first prove it cannot fit cleanly in an existing owner.
+4. **Keep scope minimal**: Implement only the simplest complete solution. Avoid impossible-state handling, speculative flags, compatibility shims, policy scaffolding, and unrelated cleanup. Tests are out of scope by default — rely on existing coverage and focused validation; only an uncovered, high-risk regression path justifies minimal new test code.
+5. **Ship zero-regression, production-ready changes**: Understand what you remove instead of retaining broken code as insurance. Remove unused imports, functions, types, files, and comments; run relevant cleanup checks; and thoroughly debug and validate the changed owner. Do not break existing features or workflows unless the PR intentionally removes them with evidence.
 
-1. **Never guard a symptom — relocate the trigger.** A fix that adds a condition to suppress bad behavior (a staleness check, an is-initialized flag, a skip-first-call guard, a try/except around broken logic) is wrong by default. Find the code path that should own the behavior, move the logic there, and delete the code that got it wrong. Example: a warning fired from stale state; the right fix was not a recency guard — it deleted the stale detection and moved the trigger into the code path that observes the event live.
-2. **Bugfixes are net-negative by default.** A bugfix that adds more lines than it removes needs a one-sentence justification in the PR body naming why deletion and relocation were impossible.
-3. **Search the repo before creating anything.** Before building a feature or helper, search the whole repo — it likely exists (`utils.py` holds the shared helpers imported by both converters). If two modules grow the same logic, consolidate into `utils.py` and delete the duplicates. Avoid premature abstraction — three similar lines beat a helper nobody else calls.
-4. **Deletion beats caution.** Zero regression means understanding the code you remove, not leaving it in place as insurance. Keeping broken or duplicated code "to be safe" is itself the regression: it is how repos rot. All changes must still ship debugged, validated, and production ready.
+**Review gate:** for every addition, the reviewer decides whether deleting or changing existing code would have fixed the problem instead — if it would, that is a blocking finding. A missing or thin PR description is never itself a finding.
 
-**Output gate:** every PR body must contain a `Deleted:` line naming the code removed (functions, branches, files, config). Features must name what they reused or consolidated. `Deleted: nothing` demands the rule-2 justification.
-
-**Review gate:** adversarial reviewers must answer two questions before LGTM: (a) what could have been deleted instead of added? (b) does any added condition suppress a symptom rather than relocate a trigger? A finding on either blocks LGTM.
-
-**This file is code — additions require deletions.** To add a rule here, remove or merge one. When everything is emphasized, nothing is.
-
-**NEVER push to `main`. NEVER force push.** Always start work in a new git worktree (`git worktree add`) on a feature branch and open a PR — never edit the primary checkout directly, it may hold in-flight work.
+NEVER push to `main`. NEVER force push. Always start work in a new git worktree (`git worktree add`) on a feature branch and open a PR — never edit the primary checkout directly, it may hold in-flight work.
 
 ## PR Workflow
 
 After opening a PR:
 
 1. Wait for the automated PR review and auto-format commit from Ultralytics Actions (`format.yml`), then pull and address every finding.
-2. Launch an independent adversarial review agent with cold context (just the PR diff and this file) to hunt for bugs, regressions, and Core Principles violations — use the Codex CLI, one fresh `codex exec` run per round. Fix, push, and repeat until a fresh run reports LGTM.
-3. Never fight other commits: Ultralytics Actions pushes auto-format and header commits, and multiple users may work on the same PR. `git pull --rebase` before pushing; never force-push, reset, or revert commits you did not author.
-4. After the PR merges, clean up: remove local worktrees and branches for it, then `git checkout main && git pull`.
+2. Review the full diff in-session against the Core Principles, performance, and the review gate above, then batch the fixes into one commit and push. After each round of bot or human commits, pull and resume the same reviewer on `<last-reviewed-sha>..HEAD` plus anything that delta could have invalidated. Repeat until the local head matches the live head.
+3. Hand off or merge only on a clean final pass: one cold full-diff review returning LGTM with no findings, on a head that is still live at merge time.
+4. Never fight other commits: Ultralytics Actions pushes auto-format and header commits, and multiple users may work on the same PR. `git pull --rebase` before pushing; never reset or revert commits you did not author.
+5. After the PR merges, clean up: remove local worktrees and branches for it, then `git checkout main && git pull`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The output follows the Ultralytics YOLO dataset layout:
 
 ```text
 yolo_out/
-├── data.yaml
+├── data.yaml   # LabelMe only; COCO writes one <json-stem>.yaml of class names per input file
 ├── images/
 └── labels/
 ```


### PR DESCRIPTION
- `AGENTS.md` still carried an older four-principle Core Principles block and a four-step PR Workflow that named the Codex CLI specifically. Replaced both with the canonical Ultralytics text shared across the org; the repo-specific Commands, Architecture, and Conventions sections are unchanged.
- README's output-layout tree implied every conversion writes `data.yaml`. Only `convert_labelme_json()` does; `convert_coco_json()` writes one `<json-stem>.yaml` of class names per input file (`write_coco_yaml`). Noted inline.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Clarifies repository contribution guidance and documents LabelMe versus COCO output YAML behavior. 📝

### 📊 Key Changes
- Reworked `AGENTS.md` to emphasize simple, owner-focused fixes, reuse of existing code, minimal scope, and zero-regression validation.
- Simplified the review workflow by removing mandatory adversarial-agent and PR-body requirements while retaining full-diff review and clean-head checks.
- Updated `README.md` to explain that:
  - LabelMe conversion creates a shared `data.yaml`.
  - COCO conversion creates one `<json-stem>.yaml` class-name file per input JSON.

### 🎯 Purpose & Impact
- Gives contributors and coding agents clearer, more streamlined development and review expectations. ✅
- Encourages smaller, cleaner changes by prioritizing deletion, reuse, and modifications to existing owners.
- Prevents confusion about generated dataset files, helping users locate the correct YAML configuration after conversion.
- The changes are documentation-only and should not affect converter functionality or runtime behavior. 🚀