### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the [Ultralytics Docs](https://docs.ultralytics.com/datasets/) and [issues](https://github.com/ultralytics/JSON2YOLO/issues) to see if a similar bug report already exists.
+        Please search the [Ultralytics Docs](https://docs.ultralytics.com/datasets) and [issues](https://github.com/ultralytics/JSON2YOLO/issues) to see if a similar bug report already exists.
       options:
         - label: >
             I have searched the Ultralytics [issues](https://github.com/ultralytics/JSON2YOLO/issues) and found no similar bug report.
@@ -73,7 +73,7 @@ body:
     attributes:
       label: Minimal Reproducible Example
       description: >
-        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example/).
+        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example).
       placeholder: |
         ```python
         from general_json2yolo import convert_coco_json

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,10 +3,10 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📄 Ultralytics Docs
-    url: https://docs.ultralytics.com/datasets/
+    url: https://docs.ultralytics.com/datasets
     about: Ultralytics dataset format and converter documentation
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the [Ultralytics Docs](https://docs.ultralytics.com/datasets/) and [issues](https://github.com/ultralytics/JSON2YOLO/issues) to see if a similar feature request already exists.
+        Please search the [Ultralytics Docs](https://docs.ultralytics.com/datasets) and [issues](https://github.com/ultralytics/JSON2YOLO/issues) to see if a similar feature request already exists.
       options:
         - label: >
             I have searched the Ultralytics [issues](https://github.com/ultralytics/JSON2YOLO/issues) and found no similar feature requests.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the [Ultralytics Docs](https://docs.ultralytics.com/datasets/), [issues](https://github.com/ultralytics/JSON2YOLO/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) to see if a similar question already exists.
+        Please search the [Ultralytics Docs](https://docs.ultralytics.com/datasets), [issues](https://github.com/ultralytics/JSON2YOLO/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) to see if a similar question already exists.
       options:
         - label: >
             I have searched the Ultralytics [issues](https://github.com/ultralytics/JSON2YOLO/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) and found no similar questions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # 🚀 Introduction
 
@@ -8,8 +8,8 @@ This conversion process is essential for [machine learning](https://www.ultralyt
 
 [![Ultralytics Actions](https://github.com/ultralytics/JSON2YOLO/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/JSON2YOLO/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 > **📢 Important Update**: The JSON2YOLO project is now integrated into the main Ultralytics package at https://github.com/ultralytics/ultralytics. The standalone scripts in this repository are no longer being actively updated. For the latest functionality, please use the new `convert_coco()` method described in our updated [data converter documentation](https://docs.ultralytics.com/reference/data/converter).
 


### PR DESCRIPTION
Canonicalizes every Ultralytics URL in this repository: no terminating path slashes, and one stale link refreshed to its permanent destination.

## Trailing slashes removed (8 across 5 files)

| File | URL |
| --- | --- |
| `README.md` | `https://www.ultralytics.com/` -> `https://www.ultralytics.com` |
| `README.md` | `https://community.ultralytics.com/` -> `https://community.ultralytics.com` |
| `.github/ISSUE_TEMPLATE/bug-report.yml` | `https://docs.ultralytics.com/datasets/`, `https://docs.ultralytics.com/help/minimum-reproducible-example/` |
| `.github/ISSUE_TEMPLATE/config.yml` | `https://docs.ultralytics.com/datasets/`, `https://community.ultralytics.com/` |
| `.github/ISSUE_TEMPLATE/feature-request.yml` | `https://docs.ultralytics.com/datasets/` |
| `.github/ISSUE_TEMPLATE/question.yml` | `https://docs.ultralytics.com/datasets/` |

All four slash-stripped destinations were verified live (HTTP 200). A repo-wide re-scan confirms zero remaining `ultralytics.com` URLs with a terminating path slash.

## Redirect refresh (1 accepted, 0 rejected)

- `https://reddit.com/r/ultralytics` -> `https://www.reddit.com/r/ultralytics/` (verified 301 apex -> `www`; matches the canonical form already used in the `ultralytics/ultralytics` README).

No dead links and no homepage/index collapses were reported by the scan (35 unique URLs checked).

## Deliberately left alone

- `https://ultralytics.com/discord` in `config.yml` — vanity shortlink, meant to stay a redirect.
- `https://ultralytics.com/license` headers in every Python file and the reference to them in `AGENTS.md` — written by Ultralytics Actions; already slash-free.
- `server=https%3A%2F%2Fcommunity.ultralytics.com` inside the shields.io Forums badge — URL-encoded parameter kept byte-identical.
- Non-Ultralytics hosts (`github.com/ultralytics/...` path separators, `cocodataset.org`, `linkedin.com/company/ultralytics/`) are untouched.

## Validation

Diff is URL text only — no code paths changed. `python -m compileall` clean, all eight workflow/issue-template YAML files parse, and `prettier@3.8.5 --print-width 120` reports every touched file unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Canonicalized Ultralytics URLs across the README and issue templates by removing unnecessary trailing slashes and updating the Reddit link to its `www` destination.

### 📊 Key Changes

- Removed trailing slashes from Ultralytics homepage, community, documentation, and minimal reproducible example URLs.
- Updated the README Reddit link from `reddit.com/r/ultralytics` to `www.reddit.com/r/ultralytics/`.
- Preserved intentional redirects, URL-encoded badge parameters, license headers, and non-Ultralytics URLs.
- Changes are limited to URL text; no code paths were modified.

### 🎯 Purpose & Impact

- Repository documentation and issue-template links now use the selected canonical URL forms.
- No user-facing change beyond link normalization and the updated Reddit destination.